### PR TITLE
Point manifest at official CTS release branch

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -58,7 +58,7 @@
   <!--<project path="art" name="CyanogenMod/android_art" groups="pdk" />-->
   <!--<project path="bionic" name="CyanogenMod/android_bionic" groups="pdk" />-->
   <!--<project path="bootable/recovery" name="CyanogenMod/android_bootable_recovery" groups="pdk" />-->
-  <project path="cts" name="CyanogenMod/android_cts" groups="cts,pdk-cw-fs,pdk-fs" />
+  <project path="cts" name="platform/cts" groups="cts,pdk-cw-fs,pdk-fs" revision="marshmallow-cts-release" remote="aosp" />
   <project path="development" name="CyanogenMod/android_development" groups="pdk-cw-fs,pdk-fs" />
   <project path="device/common" name="CyanogenMod/android_device_common" groups="pdk-cw-fs,pdk-fs" />
   <project path="device/generic/arm64" name="CyanogenMod/android_device_generic_arm64" groups="pdk" />


### PR DESCRIPTION
 * The current branch tagged as 6.0.1_r3 is NOT the current release.
 * WWJBQD?
 * We almost always want to be using the release version as a reference,
   so just point to AOSP.

Change-Id: I965f547747460919c22a2563b108707bc6ca9ae1

Conflicts:
	default.xml